### PR TITLE
Refactor authentication state management and landing UI

### DIFF
--- a/starbase/ai-roomchat/components/AuthButton.module.css
+++ b/starbase/ai-roomchat/components/AuthButton.module.css
@@ -1,0 +1,55 @@
+.button {
+  padding: 14px 40px;
+  border-radius: 999px;
+  background-color: #040507;
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  font-family: 'Noto Sans KR', sans-serif;
+  background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(30, 64, 175, 0.4));
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.button:disabled {
+  opacity: 0.65;
+  cursor: default;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  transform: none;
+}
+
+.pendingIcon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  border: 2px solid rgba(226, 232, 240, 0.4);
+  border-right-color: rgba(226, 232, 240, 0.85);
+  animation: spin 0.8s linear infinite;
+  margin-right: 12px;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}

--- a/starbase/ai-roomchat/components/LogoutButton.js
+++ b/starbase/ai-roomchat/components/LogoutButton.js
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react'
 
-import { supabase } from '../lib/supabase'
+import { useAuth } from '../hooks/useAuth'
 
 function getInitials(name) {
   if (!name) return '유'
@@ -13,6 +13,7 @@ function getInitials(name) {
 }
 
 export default function LogoutButton({ onAfter, avatarUrl, displayName }) {
+  const { signOut } = useAuth()
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
 
@@ -33,14 +34,15 @@ export default function LogoutButton({ onAfter, avatarUrl, displayName }) {
     }
   }, [open])
 
-  async function signOut() {
-    const { error } = await supabase.auth.signOut()
-    if (error) {
-      alert(error.message)
-      return
+  async function handleSignOut() {
+    try {
+      await signOut()
+      setOpen(false)
+      if (onAfter) onAfter()
+    } catch (error) {
+      console.error('Failed to sign out', error)
+      alert(error?.message || '로그아웃 중 오류가 발생했습니다.')
     }
-    setOpen(false)
-    if (onAfter) onAfter()
   }
 
   const initials = getInitials(displayName)
@@ -107,7 +109,7 @@ export default function LogoutButton({ onAfter, avatarUrl, displayName }) {
           </div>
           <button
             type="button"
-            onClick={signOut}
+            onClick={handleSignOut}
             style={{
               padding: '10px 12px',
               borderRadius: 10,

--- a/starbase/ai-roomchat/contexts/AuthContext.js
+++ b/starbase/ai-roomchat/contexts/AuthContext.js
@@ -1,0 +1,159 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+
+import { deriveProfile, DEFAULT_PROFILE } from '../lib/profile'
+import { supabase } from '../lib/supabase'
+
+const AuthContext = createContext(null)
+
+function useIsMounted() {
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return mountedRef
+}
+
+async function exchangeCodeIfPresent() {
+  if (typeof window === 'undefined') return
+  const { href } = window.location
+  if (!href || !href.includes('code=')) return
+
+  const currentUrl = new URL(href)
+  const authCode = currentUrl.searchParams.get('code')
+  if (!authCode) return
+
+  const { error } = await supabase.auth.exchangeCodeForSession({ authCode })
+  if (error) {
+    throw error
+  }
+
+  const cleanedUrl = `${currentUrl.origin}${currentUrl.pathname}${currentUrl.hash || ''}`
+  window.history.replaceState({}, document.title, cleanedUrl)
+}
+
+export function AuthProvider({ children }) {
+  const mountedRef = useIsMounted()
+  const [state, setState] = useState({
+    status: 'loading',
+    session: null,
+    user: null,
+    profile: { ...DEFAULT_PROFILE },
+    error: '',
+  })
+
+  const setStateSafe = useCallback((updater) => {
+    if (!mountedRef.current) return
+    setState((previous) => (typeof updater === 'function' ? updater(previous) : updater))
+  }, [mountedRef])
+
+  const refresh = useCallback(async () => {
+    setStateSafe((previous) => ({
+      ...previous,
+      status: 'loading',
+      error: '',
+    }))
+
+    try {
+      await exchangeCodeIfPresent()
+
+      const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
+      if (sessionError) {
+        throw sessionError
+      }
+
+      let session = sessionData?.session || null
+      let user = session?.user || null
+
+      if (!user) {
+        const { data: userData, error: userError } = await supabase.auth.getUser()
+        if (userError) {
+          throw userError
+        }
+        user = userData?.user || null
+        session = session || null
+      }
+
+      const profile = deriveProfile(user)
+
+      setStateSafe({
+        status: 'ready',
+        session,
+        user,
+        profile,
+        error: '',
+      })
+
+      return { session, user }
+    } catch (error) {
+      console.error('Failed to refresh auth state', error)
+      const message =
+        error?.message || '인증 정보를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'
+
+      setStateSafe({
+        status: 'error',
+        session: null,
+        user: null,
+        profile: { ...DEFAULT_PROFILE },
+        error: message,
+      })
+
+      return { error }
+    }
+  }, [setStateSafe])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function initialise() {
+      if (cancelled) return
+      await refresh()
+    }
+
+    initialise()
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(() => {
+      if (cancelled) return
+      refresh()
+    })
+
+    return () => {
+      cancelled = true
+      subscription?.subscription?.unsubscribe?.()
+    }
+  }, [refresh])
+
+  const signOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      throw error
+    }
+    await refresh()
+  }, [refresh])
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      isAuthenticated: Boolean(state.user),
+      refresh,
+      signOut,
+    }),
+    [state, refresh, signOut]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider')
+  }
+  return context
+}

--- a/starbase/ai-roomchat/docs/project-assessment.md
+++ b/starbase/ai-roomchat/docs/project-assessment.md
@@ -1,0 +1,21 @@
+# Project Assessment
+
+## Overview
+- **Framework**: Next.js 14 Pages Router with React 18 and Supabase integrations for auth, storage, and realtime features.【F:README.md†L1-L43】
+- **Key Modules**: Dynamic Supabase table resolution utilities, ranking battle client engine, shared chat dock, and maker editor support advanced gameplay and collaborative features.【F:lib/supabaseTables.js†L1-L66】【F:components/rank/StartClient/useStartClientEngine.js†L1-L200】
+
+## Build & Dependency Health
+- `npm install` completes without dependency resolution errors but reports three vulnerabilities (two low, one critical); remediation would require manual review or `npm audit fix --force`.【859dc9†L1-L11】
+- `npm run build` succeeds, indicating the code compiles and all pages generate correctly in production mode.【9e8fad†L1-L33】
+
+## Repair vs Rebuild Considerations
+- **Existing Feature Depth**: The project already ships gameplay orchestration, Supabase storage policies, and multiple advanced interfaces. Rebuilding from scratch would mean recreating complex engines and Supabase wiring that are currently functioning.【F:README.md†L37-L49】【F:lib/supabaseTables.js†L1-L66】【F:components/rank/StartClient/useStartClientEngine.js†L1-L200】
+- **Maintainability**: The codebase follows modular patterns (hooks, providers, utilities), making targeted refactors feasible. Incremental cleanup (linting, typing, dependency upgrades) appears more cost-effective than a rewrite.
+- **Immediate Issues**: Aside from the noted vulnerabilities, no blocking build errors surfaced. Focus can stay on auditing security warnings, writing tests, and pruning unused modules rather than rewriting the foundation.【859dc9†L1-L11】【9e8fad†L1-L33】
+
+## Suggested Next Steps
+1. Audit and address reported npm vulnerabilities; evaluate breaking changes before applying force fixes.【859dc9†L1-L11】
+2. Add automated lint/test workflows to catch regressions and improve confidence in future refactors.
+3. Document module ownership and usage to streamline onboarding and incremental modernization.
+
+**Recommendation**: Pursue targeted refactoring and stabilization instead of a full rebuild. The compiled build and existing feature coverage suggest the project is repairable with manageable effort.

--- a/starbase/ai-roomchat/hooks/roster/useRoster.js
+++ b/starbase/ai-roomchat/hooks/roster/useRoster.js
@@ -5,39 +5,17 @@ import { useRouter } from 'next/router'
 
 import { supabase } from '../../lib/supabase'
 import { withTable } from '../../lib/supabaseTables'
+import { useAuth } from '../useAuth'
 
-const DEFAULT_PROFILE_NAME = '사용자'
-
-function deriveProfile(user) {
-  if (!user) {
-    return {
-      displayName: DEFAULT_PROFILE_NAME,
-      avatarUrl: null,
-    }
-  }
-
-  const metadata = user.user_metadata || {}
-  const displayName =
-    metadata.full_name ||
-    metadata.name ||
-    metadata.nickname ||
-    (typeof user.email === 'string' ? user.email.split('@')[0] : '') ||
-    DEFAULT_PROFILE_NAME
-  const avatarUrl = metadata.avatar_url || metadata.picture || metadata.avatar || null
-
-  return { displayName, avatarUrl }
-}
+const DEFAULT_ERROR_MESSAGE = '로스터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.'
 
 export function useRoster({ onUnauthorized } = {}) {
   const router = useRouter()
+  const { status: authStatus, user, profile, error: authError } = useAuth()
   const isMounted = useRef(true)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(authStatus !== 'ready')
   const [error, setError] = useState('')
   const [heroes, setHeroes] = useState([])
-  const [{ displayName, avatarUrl }, setProfile] = useState({
-    displayName: DEFAULT_PROFILE_NAME,
-    avatarUrl: null,
-  })
 
   useEffect(() => {
     return () => {
@@ -45,86 +23,25 @@ export function useRoster({ onUnauthorized } = {}) {
     }
   }, [])
 
-  const loadRoster = useCallback(async () => {
-    if (!isMounted.current) return
+  useEffect(() => {
+    if (typeof window === 'undefined' || !user?.id) {
+      return
+    }
+
+    try {
+      window.localStorage.setItem('selectedHeroOwnerId', user.id)
+    } catch (storageError) {
+      console.error('Failed to persist roster owner metadata:', storageError)
+    }
+  }, [user?.id])
+
+  const loadHeroes = useCallback(async () => {
+    if (!user?.id) return
 
     setLoading(true)
     setError('')
 
     try {
-      const href = typeof window !== 'undefined' ? window.location.href : ''
-
-      if (href.includes('code=')) {
-        try {
-          const currentUrl = new URL(href)
-          const authCode = currentUrl.searchParams.get('code')
-          if (authCode) {
-            const result = await supabase.auth.exchangeCodeForSession({ authCode })
-            if (result?.error) {
-              throw result.error
-            }
-          }
-          if (typeof window !== 'undefined') {
-            const cleanUrl = href.split('?')[0]
-            window.history.replaceState({}, document.title, cleanUrl)
-          }
-        } catch (exchangeError) {
-          console.error('Failed to process auth callback for roster:', exchangeError)
-          if (!isMounted.current) return
-          setError('로그인 세션을 복구하지 못했습니다. 다시 시도해 주세요.')
-          setLoading(false)
-          return
-        }
-      }
-
-      const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
-      if (!isMounted.current) return
-
-      if (sessionError) {
-        setError(sessionError.message)
-        setLoading(false)
-        return
-      }
-
-      let user = sessionData?.session?.user || null
-
-      if (!user) {
-        const {
-          data: { user: fetchedUser },
-          error: authError,
-        } = await supabase.auth.getUser()
-
-        if (!isMounted.current) return
-
-        if (authError) {
-          setError(authError.message)
-          setLoading(false)
-          return
-        }
-
-        user = fetchedUser || null
-      }
-
-      if (!user) {
-        setLoading(false)
-        if (typeof onUnauthorized === 'function') {
-          onUnauthorized()
-        } else {
-          router.replace('/')
-        }
-        return
-      }
-
-      setProfile(deriveProfile(user))
-
-      if (typeof window !== 'undefined') {
-        try {
-          window.localStorage.setItem('selectedHeroOwnerId', user.id)
-        } catch (storageError) {
-          console.error('Failed to persist roster owner metadata:', storageError)
-        }
-      }
-
       const { data, error: heroesError } = await withTable(
         supabase,
         'heroes',
@@ -143,6 +60,7 @@ export function useRoster({ onUnauthorized } = {}) {
         setHeroes([])
       } else {
         setHeroes(data || [])
+
         if (typeof window !== 'undefined') {
           const storedHeroId = window.localStorage.getItem('selectedHeroId')
           if (storedHeroId && !(data || []).some((hero) => hero.id === storedHeroId)) {
@@ -154,19 +72,41 @@ export function useRoster({ onUnauthorized } = {}) {
           }
         }
       }
-
-      setLoading(false)
     } catch (err) {
       console.error(err)
       if (!isMounted.current) return
-      setError('로스터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
-      setLoading(false)
+      setError(DEFAULT_ERROR_MESSAGE)
+    } finally {
+      if (isMounted.current) {
+        setLoading(false)
+      }
     }
-  }, [onUnauthorized, router])
+  }, [user?.id])
 
   useEffect(() => {
-    loadRoster()
-  }, [loadRoster])
+    if (authStatus === 'loading') {
+      setLoading(true)
+      return
+    }
+
+    if (authStatus === 'error') {
+      setError(authError || '로그인 상태를 확인하지 못했습니다. 다시 시도해 주세요.')
+      setLoading(false)
+      return
+    }
+
+    if (!user) {
+      setLoading(false)
+      if (typeof onUnauthorized === 'function') {
+        onUnauthorized()
+      } else {
+        router.replace('/')
+      }
+      return
+    }
+
+    void loadHeroes()
+  }, [authStatus, authError, loadHeroes, onUnauthorized, router, user])
 
   const deleteHero = useCallback(async (heroId) => {
     const { error: deleteError } = await withTable(supabase, 'heroes', (table) =>
@@ -186,10 +126,10 @@ export function useRoster({ onUnauthorized } = {}) {
     loading,
     error,
     heroes,
-    displayName,
-    avatarUrl,
+    displayName: profile?.displayName || '사용자',
+    avatarUrl: profile?.avatarUrl || null,
     setError,
     deleteHero,
-    reload: loadRoster,
+    reload: loadHeroes,
   }
 }

--- a/starbase/ai-roomchat/hooks/useAuth.js
+++ b/starbase/ai-roomchat/hooks/useAuth.js
@@ -1,0 +1,7 @@
+'use client'
+
+import { useAuthContext } from '../contexts/AuthContext'
+
+export function useAuth() {
+  return useAuthContext()
+}

--- a/starbase/ai-roomchat/lib/profile.js
+++ b/starbase/ai-roomchat/lib/profile.js
@@ -1,0 +1,33 @@
+const DEFAULT_PROFILE_BASE = {
+  displayName: '사용자',
+  avatarUrl: null,
+}
+
+export const DEFAULT_PROFILE = Object.freeze({ ...DEFAULT_PROFILE_BASE })
+
+function normaliseEmail(email) {
+  if (typeof email !== 'string') return ''
+  const [localPart] = email.split('@')
+  return localPart || ''
+}
+
+export function deriveProfile(user) {
+  if (!user) {
+    return { ...DEFAULT_PROFILE_BASE }
+  }
+
+  const metadata = user.user_metadata || {}
+  const displayName =
+    metadata.full_name ||
+    metadata.name ||
+    metadata.nickname ||
+    normaliseEmail(user.email) ||
+    DEFAULT_PROFILE_BASE.displayName
+
+  const avatarUrl = metadata.avatar_url || metadata.picture || metadata.avatar || null
+
+  return {
+    displayName,
+    avatarUrl,
+  }
+}

--- a/starbase/ai-roomchat/pages/_app.js
+++ b/starbase/ai-roomchat/pages/_app.js
@@ -1,6 +1,12 @@
 import React from 'react'
+
+import { AuthProvider } from '../contexts/AuthContext'
 import '../styles/globals.css'
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  )
 }

--- a/starbase/ai-roomchat/styles/LandingPage.module.css
+++ b/starbase/ai-roomchat/styles/LandingPage.module.css
@@ -1,0 +1,43 @@
+.landing {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 64px 24px 120px;
+  background-image: url('/landing/celestial-frontline.svg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  color: #ffffff;
+  text-align: center;
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+.title {
+  font-size: clamp(32px, 5vw, 56px);
+  font-weight: 700;
+  margin-bottom: 32px;
+  text-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  letter-spacing: 0.04em;
+}
+
+.cta {
+  margin-top: auto;
+}
+
+.statusMessage {
+  margin-top: 28px;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #cbd5f5;
+  font-size: 14px;
+  max-width: 360px;
+}
+
+.statusMessageError {
+  color: #fca5a5;
+}


### PR DESCRIPTION
## Summary
- centralize Supabase authentication state handling in a reusable AuthProvider and helper hook
- update roster data flow, landing redirect, and session controls to consume the shared auth state
- restyle the landing page with CSS modules while preserving the original look and adding status feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d71f409f048328b79b6f6975048d18