### PR TITLE
Clarify matchmaking page blueprint

### DIFF
--- a/starbase/ai-roomchat/docs/match-mode-structure.md
+++ b/starbase/ai-roomchat/docs/match-mode-structure.md
@@ -46,6 +46,33 @@
 4. 듀오 큐가 솔로 큐와 함께 매칭되도록 `matchRankParticipants`를 파티 크기 가변 구조로 보강.
 5. 캐주얼 사설 방 전용 어댑터(슬롯 점유·관전 입장)를 작성.
 
+## 매칭 화면 청사진
+아래 섹션은 `/rank/[id]`에서 모드를 선택했을 때 어떤 화면과 상태 흐름이 이어지는지, 현재 코드가 암시하는 의도를 정리한 것입니다.
+
+### 스타트 모달 → 모드별 경로
+`GameStartModeModal`에서 모드를 고른 뒤에는 `/rank/[id].js`가 세션 프리셋(`rank.start.*`)을 저장하고 솔로·듀오·캐주얼 매칭/사설 방 화면으로 이동하도록 라우팅합니다.【F:starbase/ai-roomchat/pages/rank/[id].js†L174-L215】 솔로/듀오/캐주얼 매칭 페이지는 아직 비어 있지만, 이미 존재하는 클라이언트 컴포넌트를 붙여 완성할 수 있도록 설계돼 있습니다.
+
+### 솔로 랭크 매칭 흐름
+- `/rank/[id]/solo`에는 `SoloMatchClient`를 붙이는 것이 전제되어 있으며, 이 컴포넌트는 랭크 솔로 모드로 `MatchQueueClient`를 그대로 사용합니다.【F:starbase/ai-roomchat/components/rank/SoloMatchClient.js†L3-L12】
+- `MatchQueueClient`는 진입 즉시 `useMatchQueue` 훅을 활성화하고, 잠금된 역할 또는 첫 번째 역할 정보를 사용해 자동 참가를 시도합니다. 대기열 상태, 타이머 투표, 매치 확정 시 전투 화면으로 이동하는 로직이 한 곳에 모여 있습니다.【F:starbase/ai-roomchat/components/rank/MatchQueueClient.js†L154-L235】
+- `useMatchQueue`는 Supabase에서 사용자·역할 정보를 읽어오고, `/api/rank/match`를 주기적으로 호출해 매치 배정과 히어로 메타를 동기화합니다. 참가/취소 시에는 `enqueueParticipant`, `removeQueueEntry` 등 서비스 계층을 통해 큐 테이블을 직접 조작하도록 의도돼 있습니다.【F:starbase/ai-roomchat/components/rank/hooks/useMatchQueue.js†L1-L355】
+
+### 듀오 랭크 팀 편성 흐름
+- 듀오 모드 진입 시에는 `DuoRoomClient`가 로컬 세션 스토리지(`duoRooms:*`)에 저장된 파티 목록을 불러오고, 선택한 역할에 맞춘 방을 만들거나 참여하도록 합니다.【F:starbase/ai-roomchat/components/rank/DuoRoomClient.js†L6-L120】【F:starbase/ai-roomchat/components/rank/DuoRoomClient.js†L200-L382】
+- 각 방은 2~3인 정원을 가지며(역할 정원 기반), 호스트만 시작 버튼을 눌러 `onLaunch` 콜백을 호출할 수 있습니다. 모든 멤버가 `ready` 상태여야 출발하며, 출발 시 방은 세션 스토리지에서 제거돼 큐와의 중복을 피합니다.【F:starbase/ai-roomchat/components/rank/DuoRoomClient.js†L221-L382】
+- 듀오 방은 결국 솔로와 동일한 랭크 큐 그룹으로 흘러가도록 `MATCH_MODE_CONFIGS`가 queueModes를 공유하고 있어, 듀오 파티가 만들어지면 곧바로 동일한 매칭 풀로 이어붙일 수 있게 설계돼 있습니다.【F:starbase/ai-roomchat/lib/rank/matchModes.js†L29-L56】
+
+### 캐주얼 매칭 흐름
+- 캐주얼 매칭 페이지는 `CasualMatchClient`를 통해 `MatchQueueClient`를 `casual_match` 모드로 감싸는 형태입니다. 솔로 랭크와 동일한 구조지만, 매칭 키만 캐주얼 전용으로 바꿉니다.【F:starbase/ai-roomchat/components/rank/CasualMatchClient.js†L3-L12】
+- 매칭 설정은 `MATCH_MODE_CONFIGS`에서 별도의 큐 그룹(`casual`)과 파티 사이즈(최대 4인)를 갖도록 정의돼 있어, 솔로/듀오 랭크와 격리된 풀에서 빠르게 큐를 돌리는 것이 기본 의도입니다.【F:starbase/ai-roomchat/lib/rank/matchModes.js†L59-L70】
+
+### 캐주얼 사설 방 흐름
+- `/rank/[id]/casual-private`는 이미 구현된 페이지로, `CasualPrivateClient`가 역할 슬롯 템플릿을 기반으로 세션 스토리지에 사설 방을 구성합니다.【F:starbase/ai-roomchat/pages/rank/[id]/casual-private.js†L1-L62】【F:starbase/ai-roomchat/components/rank/CasualPrivateClient.js†L234-L420】
+- 호스트는 슬롯별로 참가자를 배치하고 준비 상태를 확인한 뒤, 모든 슬롯이 `ready`면 `onLaunch`를 통해 `/rank/[id]/start?mode=casual_private`로 이동합니다. 이동 시 방 데이터는 세션에서 지워져 재입장을 방지합니다.【F:starbase/ai-roomchat/pages/rank/[id]/casual-private.js†L63-L96】【F:starbase/ai-roomchat/components/rank/CasualPrivateClient.js†L293-L410】
+
+### 큐 설계에 드러난 의도
+`MATCH_MODE_CONFIGS`는 각 모드가 어떤 큐 그룹을 공유하는지, 기본·최대 파티 크기, 관전자 허용 여부 등을 한눈에 정리하고 있어 프론트/백엔드가 동일한 룰셋을 참조할 수 있게 합니다.【F:starbase/ai-roomchat/lib/rank/matchModes.js†L29-L85】 솔로·듀오 랭크가 같은 큐 모드 배열을 공유하고, 캐주얼 매칭/사설 방이 각각 별도 그룹으로 분리된 점에서 “같은 풀에서 역할 슬롯을 채우되 입장 방식만 다르다”는 청사진을 확인할 수 있습니다.
+
 ## 참조
 - `lib/rank/matchModes.js`: 위 표를 코드로 직렬화한 설정 모듈입니다.
 - `lib/rank/matchmakingService.js`: 큐를 조회하고 매칭 헬퍼를 호출하는 서비스.

--- a/starbase/ai-roomchat/docs/page_state_map.md
+++ b/starbase/ai-roomchat/docs/page_state_map.md
@@ -1,0 +1,70 @@
+# 페이지별 상태 & 로직 지도
+
+이 문서는 주요 페이지 컴포넌트가 어떤 상태 변수와 공용 스토리지를 사용하고, 매칭/메인 게임 로직이 어떻게 연결되는지 요약합니다. (2024-03 기준 코드 분석)
+
+## 1. 글로벌 셸 & 오버레이
+- **`pages/_app.js`**: `OverlayAwareShell`이 경로를 확인해 `/character`, `/roster`, `/maker`, `/prompt` 하위에서는 공유 영웅 오버레이를 숨기고, 그 외에는 `SharedHeroOverlay`를 켭니다. `ActiveMatchOverlay`는 항상 포함되어 다른 화면에서도 실시간 매치 현황을 노출합니다.
+
+## 2. 인증 & 랜딩 플로우
+| 경로 | 주요 상태 / 훅 | 공용 스토리지 & 일관성 포인트 |
+| --- | --- | --- |
+| `/` (`pages/index.js`) | `useEffect`로 `supabase.auth.getSession()` 조회 → 세션이 있으면 `/roster`로 리디렉션. `supabase.auth.onAuthStateChange` 구독해 로그인/로그아웃 시 라우팅. | 로컬 스토리지는 건드리지 않음. 모든 이동은 Next Router를 통해 수행. |
+| `/auth-callback` (`pages/auth-callback.js`) | `msg` 상태로 진행 상황 표시. `handleOAuthCallback` 실행 후 결과에 따라 라우팅 및 메시지 업데이트. | 외부에서 설정한 OAuth 처리 결과에 따라 `/`, `/roster` 등으로 이동. |
+
+## 3. 캐릭터 & 로스터 뷰
+| 경로 | 주요 상태 / 훅 | 공용 스토리지 & 일관성 포인트 |
+| --- | --- | --- |
+| `/roster` (`pages/roster.js`) | `useRoster` 훅이 `loading`, `error`, `heroes`, `displayName`, `avatarUrl` 등 반환. 선택 시 `/character/[id]` 이동. | `useRoster`가 로그인한 사용자 ID와 영웅 목록을 로컬 스토리지 `selectedHeroOwnerId`, `selectedHeroId`와 동기화하며, 사라진 ID는 정리. |
+| `/character/[id]` (`pages/character/[id].js`) | `useCharacterDetail` 훅으로 `loading`, `error`, `hero`. 로딩/에러/권한 없음 상태를 풀스크린으로 처리. | 영웅 데이터가 로드되면 `localStorage`에 `selectedHeroId`, `selectedHeroOwnerId`를 저장하고 `hero-overlay:refresh` 이벤트 발행. |
+| `/create` (`pages/create.js`) | `CreateHeroScreen`이 `useHeroCreator` 상태(이름, 설명, 능력, 미디어 업로드 상태 등)를 관리. | `selectedHeroBackgroundUrl`을 로컬 스토리지에서 읽어 배경으로 사용. 업로드 선택 시 미리보기 상태로 저장. |
+
+## 4. 로비 & 게임 탐색
+| 경로 | 주요 상태 / 훅 | 공용 스토리지 & 일관성 포인트 |
+| --- | --- | --- |
+| `/lobby` (`pages/lobby.js`) | `activeTab`, `storedHeroId`, `backgroundUrl` 상태. `useGameBrowser` 두 번(공개/내 게임), `useLobbyStats` 한 번 사용. 탭·쿼리·정렬·선택 게임·참여 등 모든 조작을 훅이 제공. | 로컬 스토리지에서 `selectedHeroId`, `selectedHeroBackgroundUrl`을 읽어 배경과 복귀 경로를 맞춤. 게임 입장 시 `/rank/[id]`로 이동. |
+
+## 5. 랭크 허브 & 게임룸
+| 경로 | 주요 상태 / 훅 | 공용 스토리지 & 일관성 포인트 |
+| --- | --- | --- |
+| `/rank` (`pages/rank/index.js`) | `count` 상태로 전체 게임 수 표시. `GameListPanel`이 실제 목록 렌더링. | 세션 스토리지/로컬 스토리지 접근 없음. |
+| `/rank/[id]` (`pages/rank/[id].js`) | 페이지 로컬 상태: `showLeaderboard`, `pickRole`, `showStartModal`, `startPreset`, `turnTimerVote(s)` 등. `useGameRoom`에서 `game`, `roles`, `participants`, `myHero`, `recentBattles`, `canStart`, `isOwner` 등 수신. | `useGameRoom`이 로컬 스토리지 `selectedHeroId`를 읽어 참여자와 매칭. 페이지는 `rank.start.*` 키를 세션 스토리지에 저장/복원(모드, 듀오 옵션, 캐주얼 옵션, API 버전/키, 턴 타이머, 투표 현황). |
+| `/rank/[id]/solo`, `/rank/[id]/duo`, `/rank/[id]/casual-*` 등 | 각 모드는 `components/rank`의 클라이언트(예: `RankNewClient`, `MatchQueueClient`, `CasualMatchClient`)를 사용해 대기열 및 준비 UI를 구성. | 공통으로 `rank.start.*` 세션 스토리지 값을 읽어 초기 설정을 유지. |
+| `/rank/new` | 새 게임 생성 폼 컴포넌트. 생성 후 `/rank/[id]`로 이동. | 로그인 정보는 Supabase 세션 기반. |
+
+## 6. 메이커(프롬프트 세트)
+| 경로 | 주요 상태 / 훅 | 공용 스토리지 & 일관성 포인트 |
+| --- | --- | --- |
+| `/maker` (`pages/maker/index.js`) | `MakerHomeContainer`가 `useMakerHome`으로 세트 목록/에러/로딩 관리. 로컬 상태로 이름 편집, 액션 시트, 임포트 파일 상태 등을 보관. | 로컬 스토리지 `selectedHeroId`, `selectedHeroBackgroundUrl`을 읽어 뒤로 가기 경로와 배경을 일치. |
+| `/maker/[id]` | 에디터 화면이 `usePromptMaker` 계열 훅으로 세트, 프롬프트, 브릿지 변수를 관리하고, 임포트/엑스포트/공개 변수를 처리. | URL에서 세트 ID 추출해 공유. 슬롯 토큰(`slotN`) 등은 `VariableDrawer`에서 정규식으로 감지하여 일관성을 유지. |
+
+## 7. 공통 스토리지 키 & 일관성 메모
+- `selectedHeroId` / `selectedHeroOwnerId`: 로스터, 캐릭터 상세, 게임룸, 메이커, 로비에서 공통 사용. 선택된 영웅 컨텍스트를 유지.
+- `selectedHeroBackgroundUrl`: 캐릭터 생성기와 메이커, 로비 배경에서 공유.
+- `rank.start.*` (mode, duoOption, casualOption, apiVersion, apiKey, turnTimer, turnTimerVote, turnTimerVotes): 랭크 게임 시작 및 매치 대기 UI 전반에서 세션 단위로 설정을 유지.
+- 실시간 매치 오버레이는 글로벌 `_app`에 상주하며, `window.dispatchEvent('hero-overlay:refresh')` 등 커스텀 이벤트로 갱신 트리거.
+
+## 8. 매칭 로직 흐름
+1. **역할/대기열 데이터 수집**: `lib/rank/matchmakingService.loadActiveRoles`가 게임별 활성 역할과 슬롯 수를 읽고, `loadQueueEntries`가 상태 `waiting`인 대기열을 모읍니다. 필요 시 `loadParticipantPool`이 이미 방에 있는 참가자를 가상 엔트리로 변환해 큐에 추가합니다.
+2. **매처 선택**: 모드에 따라 `MATCHER_BY_KEY`에서 매처 함수를 고릅니다. (`getMatcherKey`, `getDefaultPartySize` 참조)
+3. **매칭 알고리즘** (`lib/rank/matching.js`):
+   - 역할 정의를 정규화(`normalizeRoles`)하고 총 슬롯 수를 계산합니다.
+   - 큐를 역할별 버킷으로 나누고(`buildRoleBuckets`), 점수 윈도우(랭크) 또는 슬롯 수(캐주얼)에 맞춰 그룹을 선택합니다.
+   - 필요한 슬롯을 채우면 `assignments` 배열을 반환하고, 부족할 경우 원인(`no_candidates`, `insufficient_candidates` 등)을 `error`에 기록합니다.
+   - 랭크 매칭은 점수 창(`scoreWindows`)을 단계적으로 확대하면서 anchor 그룹을 선택하여 밸런스를 맞춥니다. 캐주얼 매칭은 단순 순차 채우기 전략을 사용합니다.
+4. **Supabase 업데이트**: `markAssignmentsMatched`가 매칭된 대기열 엔트리를 `matched`로 표시하고 타임스탬프/매치 코드를 갱신합니다. 실시간 매치가 아니라면 호출 측에서 `loadParticipantPool`과 함께 남은 대기열을 재검토해 후속 처리를 이어갑니다.
+
+## 9. 메인 게임 진행 로직
+### 9.1 게임룸 준비 (`hooks/useGameRoom.js`)
+- 게임 ID로 초기 부트스트랩: 사용자 인증 확인, `rank_games`/`rank_game_roles`/`rank_game_slots`/`rank_participants`/`rank_battles`를 순차로 불러와 `game`, `roles`, `participants`, `recentBattles` 상태를 채웁니다.
+- `normalizeRoles`와 `computeRequiredSlots`로 역할 구성과 최소 필요 인원을 계산해 `canStart`, `minimumParticipants`를 파생.
+- `joinGame` 액션은 현재 선택 영웅(`myHero`)과 역할 정원(`slot_count`)을 확인한 뒤 `rank_participants`에 삽입.
+- `deleteRoom`은 게임 소유자만 실행 가능하며, 관련 테이블을 일괄 삭제 후 콜백 호출.
+
+### 9.2 시나리오 실행 (`components/rank/StartClient/useStartClientEngine.js`)
+- 초기 상태: `game`, `participants`, 스토리 그래프(`graph`), 프롬프트 히스토리, 턴 진행(`turn`, `currentNodeId`), 수동 응답, API 설정(`apiKey`, `apiVersion`), 턴 제한 타이머 등을 `useState`로 관리.
+- 게임 번들 로드(`loadGameBundle`) 후 `buildSlotsFromParticipants`로 슬롯/배역을 정렬하고, `parseRules`를 통해 시스템 메시지를 생성.
+- 각 턴마다 `pickNextEdge`로 다음 노드를 결정하고, `makeNodePrompt`로 AI 프롬프트를 생성. 사용자 입력 또는 AI 응답을 히스토리에 추가하고 `updateActiveSessionRecord`로 세션 진행 상황을 브라우저 스토리지에 저장.
+- 승리/패배 여부는 `parseOutcome`로 판정하며, 패배 시 `markActiveSessionDefeated`, 완료/중단 시 `clearActiveSessionRecord`를 호출.
+- 백그라운드 음악/이미지, 등장 영웅 이름 등을 `activeHeroAssets`, `activeActorNames` 상태에 저장해 UI가 동기화되도록 합니다.
+
+이 정리로 페이지별 상태 사용과 매칭·게임 흐름 간 연결 고리를 빠르게 파악할 수 있습니다.

--- a/starbase/ai-roomchat/docs/readme_overview.md
+++ b/starbase/ai-roomchat/docs/readme_overview.md
@@ -1,0 +1,11 @@
+# README 개요
+
+`README.md` 파일은 Supabase 기반의 AI 캐릭터 생성·채팅 웹앱 스타터를 어떻게 설정하고 사용하는지 설명하는 안내서입니다. 핵심 내용은 다음과 같습니다.
+
+- **환경 변수 구성**: `.env.example`을 기반으로 `NEXT_PUBLIC_SUPABASE_URL`과 `NEXT_PUBLIC_SUPABASE_ANON_KEY` 등을 정의해 로컬 개발 환경을 준비합니다.
+- **설치 및 실행 방법**: `npm install` 후 `npm run dev`로 개발 서버를 구동하고 `http://localhost:3000`에서 앱을 확인합니다.
+- **Supabase 초기화 절차**: Google OAuth 리디렉션 주소 설정, `supabase.sql`과 `supabase_chat.sql` 스크립트 실행, `heroes` 스토리지 버킷 생성, Realtime 테이블 활성화 과정을 순서대로 안내합니다.
+- **주요 라우트 설명**: 홈(`/`), OAuth 콜백(`/auth-callback`), 캐릭터 생성(`/create`), 캐릭터 목록(`/roster`), 공개 채팅(`/chat`) 등 페이지 역할을 요약합니다.
+- **구조 메모 하이라이트**: `lib/supabaseTables.js`의 자동 테이블 매핑, `components/rank/StartClient`의 랭킹 전투 클라이언트, `components/common/SharedChatDock`의 공용 채팅 도크, `components/maker/editor/MakerEditor`의 노드 기반 편집기, `supabase.sql`의 스키마 스크립트를 간단히 정리합니다.
+
+프로젝트 전반을 빠르게 파악하려면 `README.md`와 함께 언급된 모듈을 살펴보는 것이 좋습니다.


### PR DESCRIPTION
## Summary
- document how the rank start modal routes to future solo, duo, and casual pages
- explain the intended client components and session storage flows for solo, duo, casual match, and casual private modes
- highlight how match mode configs share queue groups and party sizes across these flows

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68daa1f0313083288b7b0cfce618559e