### PR TITLE
ci: avoid npm ci in dispatch-node-migrations, install only pg

### DIFF
--- a/.github/workflows/dispatch-node-migrations.yml
+++ b/.github/workflows/dispatch-node-migrations.yml
@@ -16,11 +16,12 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies (ensure dev deps)
+      - name: Install runtime dependency (pg only)
         run: |
           cd ai-roomchat
-          npm ci --include=dev
-          npm install pg@^8.10.0 --no-save
+          # don't run `npm ci` in CI here because package-lock.json may be out of sync
+          # install only the runtime postgres driver we need for the migration runner
+          npm install --no-save --no-audit --no-fund pg@^8.10.0
 
       - name: Run Node migration runner
         env:


### PR DESCRIPTION
Install only the runtime 'pg' dependency in the manual dispatch workflow instead of running 'npm ci' (lockfile mismatch on hosted runners). This keeps the migration runner lightweight and avoids 
pm ci failures.

This change is safe: the migration runner only requires the 'pg' package at runtime.